### PR TITLE
Resolve 405 Method Not Allowed on POST /api/documents

### DIFF
--- a/graphrag-server/src/main.rs
+++ b/graphrag-server/src/main.rs
@@ -885,8 +885,11 @@ async fn main() -> std::io::Result<()> {
                     // Documents endpoints
                     .service(
                         scope("/documents")
-                            .service(resource("").route(get().to(list_documents)))
-                            .service(resource("").route(post().to(add_document)))
+                            .service(
+                                resource("")
+                                    .route(get().to(list_documents))
+                                    .route(post().to(add_document))
+                            )
                             .service(resource("/{id}").route(delete().to(delete_document)))
                     )
                     // Query endpoints


### PR DESCRIPTION
Two separate resource("") declarations at the same path caused the second to shadow the first in Actix-web routing. Chain both GET and POST routes on a single resource instead.